### PR TITLE
Fix SEO metadata in search page

### DIFF
--- a/src/app/busca/page.js
+++ b/src/app/busca/page.js
@@ -17,6 +17,11 @@ import useFiltersStore from "../store/filtrosStore";
 import useFavoritosStore from "../store/favoritosStore";
 import useImovelStore from "../store/imovelStore";
 
+export const metadata = {
+  title: "NPi Imóveis - Busca de Imóveis de Alto Padrão",
+  description: "Encontre imóveis de alto padrão perfeito para você",
+};
+
 export default function BuscaImoveis() {
   const [imoveis, setImoveis] = useState([]); // Estado inicial como array
   const [isLoading, setIsLoading] = useState(true); // Estado para controlar o carregamento
@@ -47,19 +52,7 @@ export default function BuscaImoveis() {
   // Obter o contador de atualizações de filtros do store
   const atualizacoesFiltros = useFiltersStore((state) => state.atualizacoesFiltros);
 
-  useEffect(() => {
-    document.title = "NPi Imóveis - Busca de Imóveis de Alto Padrão";
 
-    const metaDesc = document.querySelector("meta[name='description']");
-    if (metaDesc) {
-      metaDesc.setAttribute("content", "Encontre imóveis de alto padrão perfeito para você");
-    } else {
-      const meta = document.createElement("meta");
-      meta.name = "description";
-      meta.content = "Encontre imóveis de alto padrão perfeito para você";
-      document.head.appendChild(meta);
-    }
-  }, []);
 
   // Efeito para marcar quando estamos no navegador
   useEffect(() => {


### PR DESCRIPTION
## Summary
- add static metadata to the busca page
- remove runtime document.title manipulation

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_68561d74a50c832f9d5b868435399bb3