### PR TITLE
Restore previous SEO effect on search page

### DIFF
--- a/src/app/busca/page.js
+++ b/src/app/busca/page.js
@@ -48,15 +48,15 @@ export default function BuscaImoveis() {
   const atualizacoesFiltros = useFiltersStore((state) => state.atualizacoesFiltros);
 
   useEffect(() => {
-    document.title = "NPi Imóveis - Busca de Imóveis de Alto Padrão";
+    document.title = "NPi Imóveis - Busca de Imóveis";
 
     const metaDesc = document.querySelector("meta[name='description']");
     if (metaDesc) {
-      metaDesc.setAttribute("content", "Encontre imóveis de alto padrão perfeito para você");
+      metaDesc.setAttribute("content", "Encontre o imóvel perfeito para você");
     } else {
       const meta = document.createElement("meta");
       meta.name = "description";
-      meta.content = "Encontre imóveis de alto padrão perfeito para você";
+      meta.content = "Encontre o imóvel perfeito para você";
       document.head.appendChild(meta);
     }
   }, []);


### PR DESCRIPTION
## Summary
- restore search page to earlier version with SEO effect

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_685624dc9b20832f91f55095807a5324